### PR TITLE
Added Remote JSON Importer + Initial Test.

### DIFF
--- a/ds.js
+++ b/ds.js
@@ -668,20 +668,20 @@
   };
 
   _.extend(DS.Importers.Remote.prototype, 
-      DS.Importers.prototype, 
-      DS.Importers.Obj.prototype, 
-      {
-        fetch : function(options) {
-          
-          // call the original parse method of object parsing.
-          var callback = _.bind(function(data) {
-            this._data = this.parse(data);
-            DS.Importers.Obj.prototype.fetch.apply(this, [options]);
-          }, this);
+    DS.Importers.prototype, 
+    DS.Importers.Obj.prototype, 
+    {
+      fetch : function(options) {
+        
+        // call the original parse method of object parsing.
+        var callback = _.bind(function(data) {
+          this._data = this.parse(data);
+          DS.Importers.Obj.prototype.fetch.apply(this, [options]);
+        }, this);
 
-          // make ajax call to fetch remote url.
-          $.ajax(this.params).success(callback);
-      }
+        // make ajax call to fetch remote url.
+        $.ajax(this.params).success(callback);
+    }
   });
   
   DS.VERSION = "0.0.1";

--- a/ds.js
+++ b/ds.js
@@ -668,7 +668,6 @@
     this.params = {
       type : "GET",
       url : this._url,
-      async: false,
       dataType : options.jsonp ? "jsonp" : "json"
     };
 

--- a/ds.js
+++ b/ds.js
@@ -469,54 +469,54 @@
   };
 
   
+  /**
+   * Base importer class.
+   */
   DS.Importers = function() {};
 
-  _.extend(DS.Importers.prototype, {
+  /**
+   * Creates an internal representation of a column based on 
+   * the form expected by our strict json.
+   * @param {string} name The column name
+   * @param {string} type The type of the data in the column
+   */
+  DS.Importers.prototype._buildColumn = function(name, type) {
+    return {
+      _id : _.uniqueId(),
+      name : name,
+      type : type
+    };
+  };
 
-    /**
-     * Creates an internal representation of a column based on 
-     * the form expected by our strict json.
-     * @param {string} name The column name
-     * @param {string} type The type of the data in the column
-     */
-    _buildColumn: function(name, type) {
-      return {
-        _id : _.uniqueId(),
-        name : name,
-        type : type
-      };
-    }, 
+  /**
+   * Used by internal importers to cache the rows and columns
+   * in quick lookup tables for any id based operations.
+   */
+  DS.Importers.prototype._cache = function(d) {
+    d._byRowId      = {};
+    d._byColumnId   = {};
+    d._byColumnName = {};
 
-    /**
-     * Used by internal importers to cache the rows and columns
-     * in an actual quick lookup table for any id based operations.
-     */
-    _cache : function(d) {
-      d._byRowId      = {};
-      d._byColumnId   = {};
-      d._byColumnName = {};
+    // cache rows by their _ids.
+    _.each(d._rows, function(row) {
+      d._byRowId[row._id] = row;
+    });
 
-      // cache rows by their _ids.
-      _.each(d._rows, function(row) {
-        d._byRowId[row._id] = row;
-      });
+    // cache columns by their column _ids, also cache their position by name.
+    _.each(d._columns, function(column, index) {
+      column.position = index;
+      d._byColumnId[column._id] = column;
+      d._byColumnName[column.name] = column;
+    });
+  };
 
-      // cache columns by their column _ids, also cache their position by name.
-      _.each(d._columns, function(column, index) {
-        column.position = index;
-        d._byColumnId[column._id] = column;
-        d._byColumnName[column.name] = column;
-      });
-    },
-
-    /**
-    * By default we are assuming that our data is in
-    * the correct form from the fetching.
-    */
-    parse: function(data) {
-      return data;
-    }
-  });
+  /**
+  * By default we are assuming that our data is in
+  * the correct form from the fetching.
+  */
+  DS.Importers.prototype.parse = function(data) {
+    return data;
+  };
   
   /**
   * Handles basic import. 

--- a/ds.js
+++ b/ds.js
@@ -170,16 +170,27 @@
     },
 
     /**
+     * Row + value lookup private method to generalize access to the various
+     * caches.
+     * @param {string} rowcache The row cache name (_rows | _byRowId)
+     * @param {number} index The position|id of the element.
+     * @param {string} column The column name for the value being fetched. optional.
+     */
+    _get : function(rowcache, index, column) {
+      if (column) {
+        return this[rowcache][index].data[this._byColumnName[column].position];
+      } else {
+        return this[rowcache][index];
+      }
+    },
+
+    /**
      * Returns a row based on its position in the rows array.
      * @param {number} index The position in the rows array (0 - for first row, etc.)
      * @param {string} column The name of the column for which the value is being fetched.
      */
     get : function(index, column) {
-      if (column) {
-        return this._rows[index].data[this._byColumnName[column].position];
-      } else {
-        return this._rows[index];
-      }
+      return this._get("_rows", index, column);
     },
 
     /**
@@ -189,11 +200,7 @@
      * @param {string} column The name of the column for which the value is being fetched.
      */
     getByRowId : function(rid, column) {
-      if (column) {
-        return this._byRowId[rid].data[this._byColumnName[column].position];
-      } else {
-        return this._byRowId[rid];
-      }
+      return this._get("_byRowId", rid, column);
     },
 
     /**

--- a/test/data/alphabet_obj.js
+++ b/test/data/alphabet_obj.js
@@ -1,4 +1,4 @@
-[   
+window.DS.alphabet_obj = [   
     { "character":"α", "name":"alpha", "is_modern":true, "numeric_value":1 },
     { "character":"β", "name":"beta", "is_modern":true, "numeric_value":2 },
     { "character":"γ", "name":"gamma", "is_modern":true, "numeric_value":3 },
@@ -23,4 +23,4 @@
     { "character":"χ", "name":"chi", "is_modern":true, "numeric_value":600 },
     { "character":"ψ", "name":"psi", "is_modern":false, "numeric_value":700 },
     { "character":"ω", "name":"omega", "is_modern":true, "numeric_value":800 }
-] 
+];

--- a/test/data/alphabet_strict.js
+++ b/test/data/alphabet_strict.js
@@ -1,9 +1,9 @@
-{ "metadata" : {"name" : "Greek Alphabet" },
+window.DS.alphabet_strict = { "metadata" : {"name" : "Greek Alphabet" },
   "columns" : [ 
-    {"name" : "character", "type" : "String"}, 
-    {"name" : "name", "type" : "String"}, 
-    {"name" : "is_modern", "type" : "Boolean"}, 
-    {"name" : "numeric_value", "type" : "Integer"} 
+    {"name" : "character", "type" : "string"}, 
+    {"name" : "name", "type" : "string"}, 
+    {"name" : "is_modern", "type" : "boolean"}, 
+    {"name" : "numeric_value", "type" : "number"} 
   ],
   "rows" : [   
     { data : ["α","alpha",true,1] },

--- a/test/events.js
+++ b/test/events.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
   
   module("Event Building");
   (function() {
-    test("Basic event creation with delta", function() {
+    test("Basic event creation with delta", 3, function() {
       
       var obj = { "metadata" : {"name" : "Greek Alphabet" },
         "columns" : [ 
@@ -28,7 +28,7 @@ $(document).ready(function() {
 
     });
 
-    test("Basic event creation with queuing", function() {
+    test("Basic event creation with queuing", 12, function() {
       var obj = [
         {"character" : "α", "name" : "alpha", "is_modern" : true, "numeric_value" : 1}, 
         {"character" : "ε", "name" : "epsilon", "is_modern" : false, "numeric_value" : 5}
@@ -73,7 +73,7 @@ $(document).ready(function() {
   
     });
 
-    test("Basic event creation with queuing plus delta param", function() {
+    test("Basic event creation with queuing plus delta param", 14, function() {
       var obj = [
         {"character" : "α", "name" : "alpha", "is_modern" : true, "numeric_value" : 1}, 
         {"character" : "ε", "name" : "epsilon", "is_modern" : false, "numeric_value" : 5}
@@ -141,40 +141,35 @@ $(document).ready(function() {
 
     var ds = new DS({ data : obj, strict : true });
 
-    test("basic event binding on entire dataset", function() {
-      expect(1);
+    test("basic event binding on entire dataset", 1, function() {
       ds.bind("sampleevent", null, function() {
         ok(true, "sample event was triggered!");
       });
       ds.trigger("sampleevent");
     });
 
-    test("basic binding on specific row", function() {
-      expect(1);
+    test("basic binding on specific row", 1, function() {
       ds.bind("sampleevent2", {row : ds._rows[0]._id} , function() {
         ok(true, "sampleevent2 triggered with row 1");
       });
       ds.trigger("sampleevent2", { row : ds._rows[0]._id });
     });
 
-    test("basic binding on specific row from array ", function() {
-      expect(1);
+    test("basic binding on specific row from array ", 1, function() {
       ds.bind("sampleevent3", {row : ds._rows[0]._id} , function() {
         ok(true, "sampleevent3 triggered with row 1");
       });
       ds.trigger("sampleevent3", { row : [ds._rows[0]._id, ds._rows[1]._id] });
     });
 
-    test("basic binding on specific row from array reverse", function() {
-      expect(1);
+    test("basic binding on specific row from array reverse", 1, function() {
       ds.bind("sampleevent4", {row : [ds._rows[0]._id, ds._rows[1]._id]} , function() {
         ok(true, "sampleevent4 triggered with row 1");
       });
       ds.trigger("sampleevent4", { row : ds._rows[0]._id });
     });
 
-    test("multiple subscribers", function() {
-      expect(2);
+    test("multiple subscribers", 2, function() {
       ds.bind("s1", {row : [ds._rows[0]._id, ds._rows[1]._id]} , function() {
         ok(true, "s1 triggered callback 1");
       });
@@ -185,8 +180,7 @@ $(document).ready(function() {
     });
 
     // TODO: sort out why this is still triggering!
-    test("out of range shouldn't trigger", function() {
-      expect(0);
+    test("out of range shouldn't trigger", 0, function() {
       ds.bind("s2", {row : [ds._rows[0]._id, ds._rows[1]._id]} , function() {
         ok(true, "s2 triggered callback 1");
       });

--- a/test/events.js
+++ b/test/events.js
@@ -21,10 +21,10 @@ $(document).ready(function() {
       e = ds._buildEvent("update", { _id : 1, old : { "a" : "b" }, changed : { "a" : "c" }});
       ok(e.name === "update", "event name was set");
       ok(typeof e.delta !== "undefined", "delta was set");
-      // TODO uncomment this when we update underscore.js
-      // ok(_.deepEqual(e.delta[0],
-      //   { _id : 1, old : { "a" : "b" }, changed : { "a" : "c" }}
-      // ), "deltas are the same");
+      
+      ok(_.isEqual(e.delta[0],
+        { _id : 1, old : { "a" : "b" }, changed : { "a" : "c" }}
+      ), "deltas are the same");
 
     });
 
@@ -48,7 +48,7 @@ $(document).ready(function() {
 
       ok(ds._deltaQueue.length === 1, "There are deltas in the queue");
       var expectedDelta = {        
-        _id : rid,
+        _id : ds.get(rid)._id,
         old : {
           "character" : "α",
           "name" : "alpha"
@@ -58,15 +58,14 @@ $(document).ready(function() {
           "name" : "Em"
         }
       };
-      // TODO: upgrade our underscore.js version, the current one doesn't have deep equal
-      // which is needed here.
-      // ok(_.deepEqual(ds._deltaQueue[0], expectedDelta), "deltas are equal");
+      
+      ok(_.isEqual(ds._deltaQueue[0], expectedDelta), "deltas are equal");
 
       e = ds._buildEvent("update");
       ok(e.name === "update", "event name was set");
       ok(typeof e.delta !== "undefined", "delta was set");
-      // TODO uncomment this when we update underscore.js
-      // ok(_.deepEqual(e.delta[0], expectedDelta), "deltas are the same");
+      
+      ok(_.isEqual(e.delta[0], expectedDelta), "deltas are the same");
 
       ds.pop();
       ok(ds._queing === false, "no longer queing");
@@ -94,7 +93,7 @@ $(document).ready(function() {
 
       ok(ds._deltaQueue.length === 1, "There are deltas in the queue");
       var expectedDelta = {        
-        _id : rid,
+        _id : ds.get(rid)._id,
         old : {
           "character" : "α",
           "name" : "alpha"
@@ -104,17 +103,16 @@ $(document).ready(function() {
           "name" : "Em"
         }
       };
-      // TODO: upgrade our underscore.js version, the current one doesn't have deep equal
-      // which is needed here.
-      // ok(_.deepEqual(ds._deltaQueue[0], expectedDelta), "deltas are equal");
+  
+      ok(_.isEqual(ds._deltaQueue[0], expectedDelta), "deltas are equal");
 
       e = ds._buildEvent("update", {_id : 20, old : { "a" : "b" }, changed : { "a" : "c" }});
       ok(e.name === "update", "event name was set");
       ok(typeof e.delta !== "undefined", "delta was set");
       ok(e.delta.length === 2, "there are two deltas");
       ok(e.delta[1]._id === 20, "the last one is the param delta");
-      // TODO uncomment this when we update underscore.js
-      // ok(_.deepEqual(e.delta[0], expectedDelta), "deltas are the same");
+      
+      ok(_.isEqual(e.delta[0], expectedDelta), "deltas are the same");
 
       ds.pop();
       ok(ds._queing === false, "no longer queing");

--- a/test/importers.js
+++ b/test/importers.js
@@ -6,10 +6,6 @@ $(document).ready(function() {
          // check properties exist
         ok(typeof strictData._rows !== "undefined", "rows property exists");
         ok(typeof strictData._columns !== "undefined", "columns property exists");
-        
-        // check data size
-        ok(strictData._rows.length === 5, "there are 5 rows");
-        ok(strictData._columns.length === 4, "there are 4 columns");
 
         // verify all rows have ids
         _.each(strictData._rows, function(row, i) {
@@ -31,66 +27,85 @@ $(document).ready(function() {
     };
      
     module("Importing Obj");   
-    test("Convert object to dataset", function() {
-      var obj = [{"character" : "α", "name" : "alpha", "is_modern" : true, "numeric_value" : 1}, 
-        {"character" : "β", "name" : "beta", "is_modern" : true, "numeric_value" : 2}, 
-        {"character" : "γ", "name" : "gamma", "is_modern" : true, "numeric_value" : 3}, 
-        {"character" : "δ", "name" : "delta", "is_modern" : true, "numeric_value" : 4}, 
-        {"character" : "ε", "name" : "epsilon", "is_modern" : false, "numeric_value" : 5}];
-        
-      var importer = new DS.Importers.Obj(obj);
-      var strictData = importer.parse();
-      
-      verifyImport(obj, strictData);
+    test("Convert object to dataset", function() {        
+      var importer = new DS.Importers.Obj(DS.alphabet_obj);
+      importer.fetch({
+        success : function(strictData) {
+          verifyImport(DS.alphabet_obj, strictData);
 
-       // check first row
-      _.each(obj, function(row, i){
-        ok(_.isEqual(_.values(row), strictData._rows[i].data), "row " + i + " is equal");      
-        ok(typeof strictData._rows[i].data !== "undefined", "row " + i + " has an id");
+          // check data size
+          ok(strictData._rows.length === 24, "there are 5 rows");
+          ok(strictData._columns.length === 4, "there are 4 columns");
+
+           // check first row
+          _.each(DS.alphabet_obj, function(row, i){
+            ok(_.isEqual(_.values(row), strictData._rows[i].data), "row " + i + " is equal");      
+            ok(typeof strictData._rows[i].data !== "undefined", "row " + i + " has an id");
+          });
+
+          // check column types
+          ok(strictData._columns[0].name === "character", "character is first column");
+          ok(strictData._columns[0].type === "string", "character is string type");
+          ok(strictData._columns[1].name === "name", "name is 2nd column");
+          ok(strictData._columns[1].type === "string", "name is string type");
+          ok(strictData._columns[2].name === "is_modern", "is_modern is 3rd column");
+          ok(strictData._columns[2].type === "boolean", "is_modern is boolean type");
+          ok(strictData._columns[3].name === "numeric_value", "numeric_value is 4th column");
+          ok(strictData._columns[3].type === "number", "numeric_value is boolean type"); 
+        }
       });
-
-      // check column types
-      ok(strictData._columns[0].name === "character", "character is first column");
-      ok(strictData._columns[0].type === "string", "character is string type");
-      ok(strictData._columns[1].name === "name", "name is 2nd column");
-      ok(strictData._columns[1].type === "string", "name is string type");
-      ok(strictData._columns[2].name === "is_modern", "is_modern is 3rd column");
-      ok(strictData._columns[2].type === "boolean", "is_modern is boolean type");
-      ok(strictData._columns[3].name === "numeric_value", "numeric_value is 4th column");
-      ok(strictData._columns[3].type === "number", "numeric_value is boolean type"); 
-
+      
+      
     });
 
     module("Strict Importer")
     test("Basic Strict Import", function() {
-      var obj = { "metadata" : {"name" : "Greek Alphabet" },
-    "columns" : [ 
-      {"name" : "character", "type" : "string"}, 
-      {"name" : "is_modern", "type" : "boolean"}, 
-      {"name" : "name", "type" : "string"}, 
-      {"name" : "numeric_value", "type" : "number"} 
-    ],
-    "rows" : [   
-      { data : ["α","alpha",true,1] },
-      { data : ["β","beta",true,2] },
-      { data : ["γ","gamma",true,3] },
-      { data : ["δ","delta",true,4] },
-      { data : ["ε","epsilon",false,5] }]};
       
-      var importer = new DS.Importers.Strict(obj);
-      var strictData = importer.parse();
-      
-      verifyImport(obj, strictData);
+      var importer = new DS.Importers.Strict(DS.alphabet_strict);
+      importer.fetch({
+        success : function(strictData) {
+          verifyImport(DS.alphabet_strict, strictData);
+
+          // check data size
+          ok(strictData._rows.length === 24, "there are 5 rows");
+          ok(strictData._columns.length === 4, "there are 4 columns");
 
           // check column types
-      ok(strictData._columns[0].name === "character", "character is first column");
-      ok(strictData._columns[0].type === "string", "character is string type");
-      ok(strictData._columns[1].name === "is_modern", "is_modern is 2nd column");
-      ok(strictData._columns[1].type === "boolean", "is_modern is boolean type");
-      ok(strictData._columns[2].name === "name", "name is 3rd column");
-      ok(strictData._columns[2].type === "string", "name is string type");
-      ok(strictData._columns[3].name === "numeric_value", "numeric_value is 4th column");
-      ok(strictData._columns[3].type === "number", "numeric_value is number type"); 
+          ok(strictData._columns[0].name === "character", "character is first column");
+          ok(strictData._columns[0].type === "string", "character is string type");
+          
+          ok(strictData._columns[1].name === "name", "name is 2nd column");
+          ok(strictData._columns[1].type === "string", "name is string type");
+          
+          ok(strictData._columns[2].name === "is_modern", "is_modern is 3rd column");
+          ok(strictData._columns[2].type === "boolean", "is_modern is boolean type");
+
+          ok(strictData._columns[3].name === "numeric_value", "numeric_value is 4th column");
+          ok(strictData._columns[3].type === "number", "numeric_value is number type"); 
+        }
+      });
+      
+     
     });
+
+    module("Remote Importer");
+    test("Basic json url fetch", function() {
+      // This is a random yahoo pipe that just grabs the alphabet_obj.js file and
+      // pipes it back as json. Nothing clever happens here.
+      var url = "http://pipes.yahoo.com/pipes/pipe.run?_id=ea8f8a21cf15cb73a884adca0d49e227&_render=json";
+      var parser = new DS.Importers.Remote(url, { 
+        jsonp : false, 
+        parse : function(data) {
+          return data.value.items[0].json;
+        }
+      });
+      var data = parser.fetch({
+        success: function(strictData) {
+          verifyImport({}, strictData);
+        }
+      });
+      
+    });
+
   })();
 });

--- a/test/importers.js
+++ b/test/importers.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
     };
      
     module("Importing Obj");   
-    test("Convert object to dataset", function() {        
+    test("Convert object to dataset", 94, function() {        
       var importer = new DS.Importers.Obj(DS.alphabet_obj);
       importer.fetch({
         success : function(strictData) {
@@ -59,7 +59,7 @@ $(document).ready(function() {
     });
 
     module("Strict Importer")
-    test("Basic Strict Import", function() {
+    test("Basic Strict Import", 46, function() {
       
       var importer = new DS.Importers.Strict(DS.alphabet_strict);
       importer.fetch({
@@ -89,7 +89,7 @@ $(document).ready(function() {
     });
 
     module("Remote Importer");
-    test("Basic json url fetch", function() {
+    test("Basic json url fetch", 36, function() {
       // This is a random yahoo pipe that just grabs the alphabet_obj.js file and
       // pipes it back as json. Nothing clever happens here.
       var url = "http://pipes.yahoo.com/pipes/pipe.run?_id=ea8f8a21cf15cb73a884adca0d49e227&_render=json";
@@ -109,7 +109,7 @@ $(document).ready(function() {
       
     });
 
-    test("Basic jsonp url fetch", function() {
+    test("Basic jsonp url fetch", 36, function() {
       // This is a random yahoo pipe that just grabs the alphabet_obj.js file and
       // pipes it back as json. Nothing clever happens here.
       var url = "http://pipes.yahoo.com/pipes/pipe.run?_id=ea8f8a21cf15cb73a884adca0d49e227&_render=json&_callback=?";

--- a/test/importers.js
+++ b/test/importers.js
@@ -99,8 +99,30 @@ $(document).ready(function() {
           return data.value.items[0].json;
         }
       });
+      stop();
       var data = parser.fetch({
         success: function(strictData) {
+          start();
+          verifyImport({}, strictData);
+        }
+      });
+      
+    });
+
+    test("Basic jsonp url fetch", function() {
+      // This is a random yahoo pipe that just grabs the alphabet_obj.js file and
+      // pipes it back as json. Nothing clever happens here.
+      var url = "http://pipes.yahoo.com/pipes/pipe.run?_id=ea8f8a21cf15cb73a884adca0d49e227&_render=json&_callback=?";
+      var parser = new DS.Importers.Remote(url, { 
+        jsonp : true, 
+        parse : function(data) {
+          return data.value.items[0].json;
+        }
+      });
+      stop();
+      var data = parser.fetch({
+        success: function(strictData) {
+          start();
           verifyImport({}, strictData);
         }
       });

--- a/test/math.js
+++ b/test/math.js
@@ -6,11 +6,11 @@ $(document).ready(function() {
     var obj = [{a: 'test', b: 4}, {a: 6.231, b: 2}];
     var ds = new DS({ data : obj });
 
-    test("max function on all values", function() {
+    test("max function on all values", 1, function() {
       equal( 6.231 , ds.max() , "Maximum value is 6.231" )
     });
 
-    test("max function on subset of columns", function() {
+    test("max function on subset of columns", 2, function() {
       equal(4, ds.max("b"), "Max of b column is 4");
       equal(4, ds.max(["b"]), "Max of b column is 4");
     });
@@ -23,11 +23,11 @@ $(document).ready(function() {
     var obj = [{a: 'test', b: 4}, {a: 6.231, b: 2}];
     var ds = new DS({ data : obj });
 
-    test("min function on all values", function() {
+    test("min function on all values", 1, function() {
       equal( 2 , ds.min() , "Miniumum value is 2" )
     });
 
-    test("min function on subset of columns", function() {
+    test("min function on subset of columns", 3, function() {
       equal(2, ds.min("b"), "Min of b column is 2");
       equal(2, ds.min(["b"]), "Min of b column is 2");
       equal(6.231, ds.min(["a"]), "Min of a column is 6.231");

--- a/test/test.html
+++ b/test/test.html
@@ -8,6 +8,12 @@
   <script type="text/javascript" src="vendor/jslitmus.js"></script>
   <script type="text/javascript" src="../libs/underscore.js"></script>
   <script type="text/javascript" src="../ds.js"></script>
+  
+  <!-- Load data sets -->
+  <script type="text/javascript" src="data/alphabet_obj.js"></script>
+  <script type="text/javascript" src="data/alphabet_strict.js"></script>
+
+  <!-- load test modules -->
   <script type="text/javascript" src="tests.js"></script>
   <script type="text/javascript" src="importers.js"></script>
   <script type="text/javascript" src="events.js"></script>

--- a/test/tests.js
+++ b/test/tests.js
@@ -19,33 +19,33 @@ $(document).ready(function() {
         rid1 = ds._rows[0]._id,
         rid2 = ds._rows[1]._id;
 
-    test("getting values by position", function() {
+    test("getting values by position", 2, function() {
       equal(1, ds.get(pos1, "one"), "Can get the first value in the one column" )
       equal(2, ds.get(pos2, "one"), "Can get the second value in the one column" )
     });
 
-    test("getting values by id", function() {
+    test("getting values by id", 2, function() {
       equal(1, ds.getByRowId(rid1, "one"), "Can get the first value in the one column" )
       equal(2, ds.getByRowId(rid2, "one"), "Can get the second value in the one column" )
     });
 
-    test("getting a whole row by position", function() {
+    test("getting a whole row by position", 2, function() {
       ok(typeof ds.get(pos1)._id !== "undefined", "Whole row fetch has _id");
       ok(typeof ds.get(pos1).data !== "undefined", "Whole row fetch has data");
     });
 
-    test("getting a whole row by id", function() {
+    test("getting a whole row by id", 2, function() {
       ok(typeof ds.getByRowId(rid1)._id !== "undefined", "Whole row fetch has _id");
       ok(typeof ds.getByRowId(rid1).data !== "undefined", "Whole row fetch has data");
     });
 
-    test("filtering to rows via filter:row", function() {
+    test("filtering to rows via filter:row", 1, function() {
       var rid = 0,
           sub = ds.filter({ row : rid });
       equal( sub.get(rid, "one") , ds.get(rid, "one"), "Same data exists in sub dataset" )
     });
 
-    test("filtering to rows via filter:rows", function() {
+    test("filtering to rows via filter:rows", 2, function() {
       var pos1 = 0,
           pos2 = 1,
           sub = ds.filter({ rows : [pos1, pos2] });
@@ -60,7 +60,7 @@ $(document).ready(function() {
       equal( sub.get(rid, "one") , ds.get(rid, "one"), "Same data exists in sub dataset" )
     });
 
-    test("filtering by columns - first", function() {
+    test("filtering by columns - first", 5, function() {
       var sub = ds.filter({column:"one"});
       ok(sub._columns.length === 1, "only one column in new subset");
       ok(sub._rows.length === ds._rows.length, "same number of rows in both datasets");
@@ -69,7 +69,7 @@ $(document).ready(function() {
       ok(sub._rows[1].data[0] === 2, "the value that got pulled is the first value in the one column second row.");
     });
 
-    test("filtering by columns - second", function() {
+    test("filtering by columns - second", 5, function() {
       var sub = ds.filter({column:"two"});
       ok(sub._columns.length === 1, "only one column in new subset");
       ok(sub._rows.length === ds._rows.length, "same number of rows in both datasets");
@@ -82,7 +82,7 @@ $(document).ready(function() {
   module("Setting values");
   (function() {
 
-    test("Setting a single value by position", function() {
+    test("Setting a single value by position", 2, function() {
       var obj = [
         {"character" : "α", "name" : "alpha", "is_modern" : true, "numeric_value" : 1}, 
         {"character" : "ε", "name" : "epsilon", "is_modern" : false, "numeric_value" : 5}
@@ -97,7 +97,7 @@ $(document).ready(function() {
       
     });
 
-    test("Setting a single value by id", function() {
+    test("Setting a single value by id", 2, function() {
       var obj = [
         {"character" : "α", "name" : "alpha", "is_modern" : true, "numeric_value" : 1}, 
         {"character" : "ε", "name" : "epsilon", "is_modern" : false, "numeric_value" : 5}
@@ -112,7 +112,7 @@ $(document).ready(function() {
       
     });
 
-    test("Setting a single value to the same value that already exists", function(){
+    test("Setting a single value to the same value that already exists", 2, function(){
       var obj = [
         {"character" : "α", "name" : "alpha", "is_modern" : true, "numeric_value" : 1}, 
         {"character" : "ε", "name" : "epsilon", "is_modern" : false, "numeric_value" : 5}
@@ -128,7 +128,7 @@ $(document).ready(function() {
       // TODO: check that things weren't triggered here in the future.
     });
 
-    test("Setting multiple values", function() {
+    test("Setting multiple values", 4, function() {
       var obj = [
         {"character" : "α", "name" : "alpha", "is_modern" : true, "numeric_value" : 1}, 
         {"character" : "ε", "name" : "epsilon", "is_modern" : false, "numeric_value" : 5}
@@ -144,7 +144,7 @@ $(document).ready(function() {
       ok(ds.get(rid, "name") === "Em", "post set character is correct");
     });
 
-    test("Basic Queuing works on Set", function() {
+    test("Basic Queuing works on Set", 9, function() {
       var obj = [
         {"character" : "α", "name" : "alpha", "is_modern" : true, "numeric_value" : 1}, 
         {"character" : "ε", "name" : "epsilon", "is_modern" : false, "numeric_value" : 5}
@@ -197,21 +197,21 @@ $(document).ready(function() {
 
   module("Type Checking");
   (function() {
-    test("Check Boolean type", function() {
+    test("Check Boolean type", 2, function() {
       var bTValue = true,
           bFValue = false;
       ok(DS.typeOf(bTValue)=="boolean", "Value should be boolean");
       ok(DS.typeOf(bFValue)=="boolean", "Value should be boolean");
     });
 
-    test("Check number type", function() {
+    test("Check number type", 2, function() {
       var value = 12,
           value2 = 0;
       ok(DS.typeOf(value)=="number", "Value should be number");
       ok(DS.typeOf(value2)=="number", "Value should be number");
     });
 
-    test("Check number type", function() {
+    test("Check number type", 2, function() {
       var value = "cats",
           value2 = "";
       ok(DS.typeOf(value)=="string", "Value should be string");

--- a/test/tests.js
+++ b/test/tests.js
@@ -29,6 +29,16 @@ $(document).ready(function() {
       equal(2, ds.getByRowId(rid2, "one"), "Can get the second value in the one column" )
     });
 
+    test("getting a whole row by position", function() {
+      ok(typeof ds.get(pos1)._id !== "undefined", "Whole row fetch has _id");
+      ok(typeof ds.get(pos1).data !== "undefined", "Whole row fetch has data");
+    });
+
+    test("getting a whole row by id", function() {
+      ok(typeof ds.getByRowId(rid1)._id !== "undefined", "Whole row fetch has _id");
+      ok(typeof ds.getByRowId(rid1).data !== "undefined", "Whole row fetch has data");
+    });
+
     test("filtering to rows via filter:row", function() {
       var rid = 0,
           sub = ds.filter({ row : rid });
@@ -153,20 +163,19 @@ $(document).ready(function() {
       ok(ds.get(rid, "name") === "Em", "post set character is correct");
 
       ok(ds._deltaQueue.length === 1, "There are deltas in the queue");
-      // TODO: upgrade our underscore.js version, the current one doesn't have deep equal
-      // which is needed here.
-      // ok(_.deepEqual(ds._deltaQueue[0], {
+
+      ok(_.isEqual(ds._deltaQueue[0], {
         
-      //   _id : rid,
-      //   old : {
-      //     "character" : "α",
-      //     "name" : "alpha"
-      //   },
-      //   changed : {
-      //     "character" : "M",
-      //     "name" : "Em"
-      //   }
-      // }), "deltas are equal");
+        _id : ds.get(rid)._id,
+        old : {
+          "character" : "α",
+          "name" : "alpha"
+        },
+        changed : {
+          "character" : "M",
+          "name" : "Em"
+        }
+      }), "deltas are equal");
 
       ds.pop();
       ok(ds._queing === false, "no longer queing");


### PR DESCRIPTION
## Major Changes:
- Because the remote importer now requires fetching the data before actually parsing it, I added an options hash to the parse method that takes a success callback. All importers have this behavior.
- Also added support for a parse function parmeter that can be passed on importer initialization.
- Changed the alphabet data test files to just set themselves as vars on the global object so that we can reference them in tests. Not an issue really since the only time they are loaded is in the test.html.
- Modified the getter methods to return the whole row if a column is not specified. We should discuss whether this is the desired behavior or whether it should only return the data itself. I needed it because I needed access to the _id of a row in one of my tests and realized this was probably an important functionality to have. We should sort out how to handle that best.
