### PR TITLE
Added CSV importer + refactored all the importers

### DIFF
--- a/src/importers.js
+++ b/src/importers.js
@@ -76,7 +76,6 @@
         ),
         "gi"
       );
-      console.log(this.__delimiterPatterns);
       this._data = this.parse(data);
     };
 

--- a/test/data/alphabet_csv.js
+++ b/test/data/alphabet_csv.js
@@ -1,0 +1,25 @@
+window.DS.alphabet_csv="character,name,is_modern,numeric_value\n" +
+"α,alpha,true,1\n" +
+"β,beta,true,2\n" +
+"γ,gamma,true,3\n" +
+"δ,delta,true,4\n" +
+"ε,epsilon,false,5\n" +
+"ζ,zeta,true,7\n" +
+"η,eta,true,8\n" +
+"θ,theta,true,9\n" +
+"ι,iota,true,10\n" +
+"κ,kappa,true,20\n" +
+"λ,lambda,false,30\n" +
+"μ,mu,false,40\n" +
+"ν,nu,false,50\n" +
+"ξ,xi,false,60\n" +
+"ο,omicron,false,70\n" +
+"π,pi,false,80\n" +
+"ρ,rho,true,100\n" +
+"σ,sigma,false,200\n" +
+"τ,\"tau\",false,300\n" +
+"υ,upsilon,true,400\n" +
+"φ,phi,true,500\n" +
+"χ,chi,true,600\n" +
+"ψ,psi,false,700\n" +
+"ω,omega,true,800";

--- a/test/data/alphabet_customseparator.js
+++ b/test/data/alphabet_customseparator.js
@@ -1,0 +1,25 @@
+window.DS.alphabet_customseparator="character###name###is_modern###numeric_value\n" +
+"α###alpha###true###1\n" +
+"β###beta###true###2\n" +
+"γ###gamma###true###3\n" +
+"δ###delta###true###4\n" +
+"ε###epsilon###false###5\n" +
+"ζ###zeta###true###7\n" +
+"η###eta###true###8\n" +
+"θ###theta###true###9\n" +
+"ι###iota###true###10\n" +
+"κ###kappa###true###20\n" +
+"λ###lambda###false###30\n" +
+"μ###mu###false###40\n" +
+"ν###nu###false###50\n" +
+"ξ###xi###false###60\n" +
+"ο###omicron###false###70\n" +
+"π###pi###false###80\n" +
+"ρ###rho###true###100\n" +
+"σ###sigma###false###200\n" +
+"τ###\"tau\"###false###300\n" +
+"υ###upsilon###true###400\n" +
+"φ###phi###true###500\n" +
+"χ###chi###true###600\n" +
+"ψ###psi###false###700\n" +
+"ω###omega###true###800";

--- a/test/index.html
+++ b/test/index.html
@@ -29,9 +29,9 @@
 
   <!-- load test modules -->
   <script src="unit/core.js"></script>
-  <script src="unit/importers.js"></script>
-  <script src="unit/events.js"></script>
   <script src="unit/math.js"></script>
+  <script src="unit/events.js"></script>
+  <script src="unit/importers.js"></script>
 
 </head>
 <body>

--- a/test/index.html
+++ b/test/index.html
@@ -24,6 +24,8 @@
   <script src="data/short_obj.js"></script>
   <script src="data/alphabet_obj.js"></script>
   <script src="data/alphabet_strict.js"></script>
+  <script src="data/alphabet_csv.js"></script>
+  <script src="data/alphabet_customseparator.js"></script>
 
   <!-- load test modules -->
   <script src="unit/core.js"></script>

--- a/test/unit/importers.js
+++ b/test/unit/importers.js
@@ -52,8 +52,6 @@ test("Convert object to dataset", 94, function() {
       ok(strictData._columns[3].type === "number", "numeric_value is boolean type");
     }
   });
-
-
 });
 
 module("Strict Importer")
@@ -82,8 +80,6 @@ test("Basic Strict Import", 46, function() {
       ok(strictData._columns[3].type === "number", "numeric_value is number type");
     }
   });
-
-
 });
 
 module("Remote Importer");
@@ -100,8 +96,8 @@ test("Basic json url fetch", 36, function() {
   stop();
   var data = parser.fetch({
     success: function(strictData) {
-      start();
       verifyImport({}, strictData);
+      start();
     }
   });
 });
@@ -119,8 +115,64 @@ test("Basic jsonp url fetch", 36, function() {
   stop();
   var data = parser.fetch({
     success: function(strictData) {
-      start();
       verifyImport({}, strictData);
+      start();
+    }
+  });
+});
+  
+module("Delimiter Importer");
+test("Basic delimiter parsing test", 46, function() {
+  var parser = new DS.Importers.Delimited(window.DS.alphabet_csv, {});
+  parser.fetch({
+    success : function(strictData) {
+      verifyImport(DS.alphabet_strict, strictData);
+
+      // check data size
+      ok(strictData._rows.length === 24, "there are 24 rows");
+      ok(strictData._columns.length === 4, "there are 4 columns");
+
+      // check column types
+      ok(strictData._columns[0].name === "character", "character is first column");
+      ok(strictData._columns[0].type === "string", "character is string type");
+
+      ok(strictData._columns[1].name === "name", "name is 2nd column");
+      ok(strictData._columns[1].type === "string", "name is string type");
+
+      ok(strictData._columns[2].name === "is_modern", "is_modern is 3rd column");
+      ok(strictData._columns[2].type === "boolean", "is_modern is boolean type");
+
+      ok(strictData._columns[3].name === "numeric_value", "numeric_value is 4th column");
+      ok(strictData._columns[3].type === "number", "numeric_value is number type");
+    }
+  });
+});
+
+test("Basic delimiter parsing test with custom separator", 46, function() {
+  var parser = new DS.Importers.Delimited(window.DS.alphabet_customseparator, {
+    delimiter : "###"
+  });
+  parser.fetch({
+    success : function(strictData) {
+      verifyImport(DS.alphabet_strict, strictData);
+
+      console.log(strictData);
+      // check data size
+      ok(strictData._rows.length === 24, "there are " + strictData._rows.length + " rows");
+      ok(strictData._columns.length === 4, "there are 4 columns");
+
+      // check column types
+      ok(strictData._columns[0].name === "character", "character is first column");
+      ok(strictData._columns[0].type === "string", "character is string type");
+
+      ok(strictData._columns[1].name === "name", "name is 2nd column");
+      ok(strictData._columns[1].type === "string", "name is string type");
+
+      ok(strictData._columns[2].name === "is_modern", "is_modern is 3rd column");
+      ok(strictData._columns[2].type === "boolean", "is_modern is boolean type");
+
+      ok(strictData._columns[3].name === "numeric_value", "numeric_value is 4th column");
+      ok(strictData._columns[3].type === "number", "numeric_value is number type");
     }
   });
 });


### PR DESCRIPTION
Before, importers were tied to the source of the data (a var or a remote url). I separated them into "parsers" and "importers". Parsers can handle the following data:
- Obj (array of json objects.)
- Strict (our strict format.)
- Delimited (any delimited string.)

Importers can handle the following protocols:
- Local - really just a passthrough for now that handles munching the data and passing it to the right parser.
- Remote - responsabile for fetching remote url, preparing the data and passing it to the right parser.

The dataset constructor has been updated to pick the right importer and parser based on the params set by the user.

The importer tests have been updated to check all combinations as well as all relevalt instantiations of dataset that would call upon the importer combinations. 

For remote importers, I had to add a ready property to the dataset constructor that would take a callback that would be responsible for whatever behavior needed to come next once the data was loaded. It's not required for local imports (although can be specified.) This is because we're doing an async fetch and thus any use of dataset instance has to wait until that data returns, is parsed and ready.
