### PR TITLE
#120 - Min/Max now ignore any non-numeric values.

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -36,7 +36,7 @@
         return 0;
       },
       numeric : function(v) {
-        return _.isNaN( Number(v) ) ? 0 : Number(v);
+        return _.isNaN( Number(v) ) ? null : Number(v);
       }
     },
 
@@ -57,7 +57,13 @@
       },
 
       numeric : function(value) {
-        return _.isNaN(+value) ? 0 : +value;
+        if (_.isNaN(+value) || value === null) {
+          return null;
+        } else if (_.isNumber(+value)) {
+          return +value;
+        } else {
+          return null;
+        }
       }
     },
 
@@ -83,7 +89,11 @@
         return (n1 < n2 ? -1 : 1);
       },
       numeric : function(value) {
-        return (value) ? 1 : 0;
+        if (_.isNaN(value)) {
+          return null;
+        } else {
+          return (value) ? 1 : 0;  
+        }
       }
     },
 

--- a/src/view.js
+++ b/src/view.js
@@ -77,8 +77,10 @@
     _max : function() {
       var max = -Infinity;
       for (var j = 0; j < this.data.length; j++) {
-        if (Miso.types[this.type].compare(this.data[j], max) > 0) {
-          max = this.numericAt(j);
+        if (this.data[j] !== null) {
+          if (Miso.types[this.type].compare(this.data[j], max) > 0) {
+            max = this.numericAt(j);
+          }  
         }
       }
 
@@ -88,8 +90,10 @@
     _min : function() {
       var min = Infinity;
       for (var j = 0; j < this.data.length; j++) {
-        if (Miso.types[this.type].compare(this.data[j], min) < 0) {
-          min = this.numericAt(j);
+        if (this.data[j] !== null) {
+          if (Miso.types[this.type].compare(this.data[j], min) < 0) {
+            min = this.numericAt(j);
+          }  
         }
       }
       return Miso.types[this.type].coerce(min, this);

--- a/test/unit/bugs.js
+++ b/test/unit/bugs.js
@@ -5,6 +5,34 @@
 
   module("Bugs");
 
+  test("#120 - NaN values in Dataset should not fail min/max", function() {
+    
+    // min(b) should be 4, not 0
+    var data = [
+      { a : -1,   b : 10,   c : "2002", d : true  },
+      { a : -10,  b : null, c : "2001", d : false },
+      { a : -100, b : 4,    c : "2006", d : null  },
+      { a : null, b : 5,    c : null,   d : true  }
+    ];
+
+    var ds = new Miso.Dataset({
+      data : data,
+      columns : [
+        { name : "c", type : "time", format: "YYYY" }
+      ]
+    });
+
+    ds.fetch({
+      success: function() {
+        ok(ds.min("b") === 4,  "Min is: " + ds.min("b"));
+        ok(ds.max("a") === -1, "Max is: " + ds.max("a"));
+        ok(ds.max("c").valueOf() === moment("2006", "YYYY").valueOf());
+        ok(ds.min("c").valueOf() === moment("2001", "YYYY").valueOf());
+        ok(ds.min("d") === false, ds.min("d"));
+        ok(ds.max("d") === true,  ds.max("d"));
+      }
+    });
+  });
   test("#131 - Deferred object should be accessible before fetch", 1, function() {
     var key = "0Asnl0xYK7V16dFpFVmZUUy1taXdFbUJGdGtVdFBXbFE",
     worksheet = "1";

--- a/test/unit/types.js
+++ b/test/unit/types.js
@@ -176,8 +176,8 @@
   });
 
   test("String type returns 0 or coerced form", function() {
-    equals(Miso.types.string.numeric("A"), 0);
-    equals(Miso.types.string.numeric(null), 0);
+    equals(Miso.types.string.numeric("A"), null);
+    equals(Miso.types.string.numeric(null), null);
     equals(Miso.types.string.numeric("99"), 99);
     equals(Miso.types.string.numeric("99.3"), 99.3);
   });


### PR DESCRIPTION
This required adjusting the types to return null whenever they are faced with a NaN value or a value that cannot be easily cast to a number.
