### PR TITLE
More type checks for NaNs

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -24,6 +24,9 @@
     mixed : {
       name : 'mixed',
       coerce : function(v) {
+        if (_.isNull(v) || typeof v === "undefined" || _.isNaN(v)) {
+          return null;
+        }
         return v;
       },
       test : function(v) {
@@ -35,18 +38,23 @@
         return 0;
       },
       numeric : function(v) {
-        return _.isNaN( Number(v) ) ? null : Number(v);
+        return v === null || _.isNaN(+v) ? null : +v;
       }
     },
 
     string : {
       name : "string",
       coerce : function(v) {
-        return v == null ? null : v.toString();
+        if (_.isNaN(v) || v === null || typeof v === "undefined") {
+          return null;
+        }
+        return v.toString();
       },
+
       test : function(v) {
         return (v === null || typeof v === "undefined" || typeof v === 'string');
       },
+
       compare : function(s1, s2) {
         if (s1 == null && s2 != null) { return -1; }
         if (s1 != null && s2 == null) { return 1; }
@@ -70,6 +78,9 @@
       name : "boolean",
       regexp : /^(true|false)$/,
       coerce : function(v) {
+        if (_.isNaN(v) || v === null || typeof v === "undefined") {
+          return null;
+        }
         if (v === 'false') { return false; }
         return Boolean(v);
       },
@@ -88,7 +99,7 @@
         return (n1 < n2 ? -1 : 1);
       },
       numeric : function(value) {
-        if (_.isNaN(value)) {
+        if (value === null || _.isNaN(value)) {
           return null;
         } else {
           return (value) ? 1 : 0;  
@@ -100,10 +111,11 @@
       name : "number",
       regexp : /^\s*[\-\.]?[0-9]+([\.][0-9]+)?\s*$/,
       coerce : function(v) {
-        if (_.isNull(v)) {
+        var cv = +v;
+        if (_.isNull(v) || typeof v === "undefined" || _.isNaN(cv)) {
           return null;
         }
-        return _.isNaN(v) ? null : +v;
+        return cv;
       },
       test : function(v) {
         if (v === null || typeof v === "undefined" || typeof v === 'number' || this.regexp.test( v ) ) {
@@ -120,6 +132,9 @@
         return (n1 < n2 ? -1 : 1);
       },
       numeric : function(value) {
+        if (_.isNaN(value) || value === null) {
+          return null;
+        }
         return value;
       }
     },
@@ -169,6 +184,11 @@
 
       coerce : function(v, options) {
         options = options || {};
+
+        if (_.isNull(v) || typeof v === "undefined" || _.isNaN(v)) {
+          return null;
+        }
+
         // if string, then parse as a time
         if (_.isString(v)) {
           var format = options.format || this.format;
@@ -201,6 +221,9 @@
         return 0;
       },
       numeric : function( value ) {
+        if (_.isNaN(value) || value === null) {
+          return null;
+        }
         return value.valueOf();
       }
     }

--- a/test/unit/types.js
+++ b/test/unit/types.js
@@ -4,7 +4,9 @@
   var Miso    = global.Miso || {};  
 
   var numbers = ['123', '0.34', '.23'];
-  
+  var not_numbers = [null, NaN,undefined];
+
+
   module("Miso Numeric Type");
   test("Check number type", function() {
     var notNumbers = ['a', {}, 'll22'];
@@ -20,10 +22,41 @@
     });
   });
 
+  test("Check all non numeric values return null on numeric", function() {
+    expect(10);
+
+    _.each(Miso.types, function(type) {
+      // not checking undefined - we either coerrced it out and can't computationally
+      // derive it like a NaN
+      _.each([NaN, null], function(not_a_number) {
+        ok(type.numeric(not_a_number) === null, "["+type.name+"] " + not_a_number + " is represented as " + type.numeric(not_a_number));
+      });
+    });
+  });
+
+  test("Check all non numeric values return null on coerce", function() {
+    expect(15);
+
+    _.each(Miso.types, function(type) {
+      _.each(not_numbers, function(not_a_number) {
+        ok(type.coerce(not_a_number) === null, "["+type.name+"] " + not_a_number + " is represented as " + type.coerce(not_a_number));
+      });
+    });
+  });
+
+
   test("Coerce number type", function() {
     var coerced = [123, 0.34, 0.23];
     _.each(numbers, function(num, i) {
       equals(Miso.types.number.coerce(num), coerced[i], "Should return true for a number");
+    });
+  });
+
+
+  test("Coerce to null", function() {
+    var coerced = ['foo', undefined, NaN, {}];
+    _.each(coerced, function(num, i) {
+      equals(Miso.types.number.coerce(coerced[i]), null, "Should return null for invalid input");
     });
   });
 


### PR DESCRIPTION
Coerce now does not let NaNs through.
Numeric better handles null values since coerce does let nulls through. 
