### PR TITLE
Making sure _initialize routine kicks off regardless of options.

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -35,7 +35,6 @@ module.exports = function(grunt) {
           "src/sync.js",
           "src/builder.js",
           "src/product.js",
-          "src/derived.js",
           "src/importer.js",
           "src/importers/local.js",
           "src/importers/remote.js",
@@ -45,7 +44,8 @@ module.exports = function(grunt) {
           "src/parsers/strict.js",
           "src/parsers/object.js",
           "src/parsers/google_spreadsheet.js",
-          "src/parsers/delimited.js"
+          "src/parsers/delimited.js",
+          "src/derived.js"
         ]
       },
 

--- a/src/constructor.js
+++ b/src/constructor.js
@@ -33,15 +33,15 @@
   */
   global.Miso = global.Miso || {};
   global.Miso.Dataset = function(options) {
+    
+    options = options || {};
+
     this.length = 0;
     
     this._columns = [];
     this._columnPositionByName = {};
     this._computedColumns = [];
     
-    if (typeof options !== "undefined") {
-      options = options || {};
-      this._initialize(options);
-    }
+    this._initialize(options);
   };
 }(this));

--- a/test/index.html
+++ b/test/index.html
@@ -27,7 +27,6 @@
   <script src="../src/view.js"></script>
   <script src="../src/product.js"></script>
   <script src="../src/dataset.js"></script>
-  <script src="../src/derived.js"></script>
   <script src="../src/importer.js"></script>
   <script src="../src/importers/local.js"></script>
   <script src="../src/importers/remote.js"></script>
@@ -38,6 +37,7 @@
   <script src="../src/parsers/object.js"></script>
   <script src="../src/parsers/google_spreadsheet.js"></script>
   <script src="../src/parsers/delimited.js"></script>
+  <script src="../src/derived.js"></script>
 
   <!-- Load data sets -->
   <script src="data/short_obj.js"></script>
@@ -54,17 +54,6 @@
   
   <script src="unit/helpers.js"></script>
 
-  <!-- load test modules -->
-  <script src="unit/events.js"></script>
-  <script src="unit/types.js"></script>
-  <script src="unit/core.js"></script>
-  <script src="unit/dataset.js"></script>
-  <script src="unit/views.js"></script>
-  <script src="unit/importers.js"></script>
-  <script src="unit/products.js"></script>
-  <script src="unit/speed.js"></script>
-  <script src="unit/derived.js"></script>
-  <script src="unit/bugs.js"></script>
  
 </head>
 <body>
@@ -77,5 +66,17 @@
     <br />
     <h1 class="qunit-header">Speed Suite</h1>
   </div>
+
+    <!-- load test modules -->
+  <script src="unit/events.js"></script>
+  <script src="unit/types.js"></script>
+  <script src="unit/core.js"></script>
+  <script src="unit/dataset.js"></script>
+  <script src="unit/views.js"></script>
+  <script src="unit/importers.js"></script>
+  <script src="unit/products.js"></script>
+  <script src="unit/speed.js"></script>
+  <script src="unit/derived.js"></script>
+  <script src="unit/bugs.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Comes up in the perlin noise example. In constructor if `options` are blank it skips the `_initialize` routine, thus leaving `this._idAttribute = undefined`. When adding rows to this blank dataset, `this._idAttribute` is `undefined` and as a result a new property called "undefined" with a value on the row being added, breaking the actual add routine, because there is no column called "undefined".

Fixing this in the `constructor.js` results in a load order problem because in the builds derived.js is created before any of the parsers, and we need to set the default parser to the strict parser. This is because derived.js creates a new Dataset to steal its prototype.

I am triggering initialization now regardless of options state and I moved the derived.js in the build order to the bottom after importers and parsers.

This one is a bit nutty.
