### PR TITLE
Adding support for POST requests on the importer

### DIFF
--- a/src/importers/remote.js
+++ b/src/importers/remote.js
@@ -11,6 +11,8 @@
   *     extract - a method to pass raw data through before handing back to parser.
   *     dataType - ajax datatype
   *     jsonp  - true if it's a jsonp request, false otherwise.
+  *     type - wether to do a post or a get request (defaults to 'GET')
+  *     postData - The post data to send with the request
   */
   Dataset.Importers.Remote = function(options) {
     options = options || {};
@@ -20,11 +22,18 @@
 
     // Default ajax request parameters
     this.params = {
-      type : "GET",
+      type : "GET", // if you define type, otherwise "get"
       url : _.isFunction(this._url) ? _.bind(this._url, this) : this._url,
       dataType : options.dataType ? options.dataType : (options.jsonp ? "jsonp" : "json"),
       callback : options.callback
     };
+
+    // support for POST requests, just define them here.
+    if (options.hasOwnProperty('postData') && options.hasOwnProperty('type')) {
+      this.params.type = options.type;
+      this.params.data = options.postData;
+    }
+
   };
 
   _.extend(Dataset.Importers.Remote.prototype, Dataset.Importers.prototype, {

--- a/src/importers/remote.js
+++ b/src/importers/remote.js
@@ -12,7 +12,7 @@
   *     dataType - ajax datatype
   *     jsonp  - true if it's a jsonp request, false otherwise.
   *     type - wether to do a post or a get request (defaults to 'GET')
-  *     postData - The post data to send with the request
+  *     data - The post data to send with the request
   */
   Dataset.Importers.Remote = function(options) {
     options = options || {};
@@ -29,9 +29,9 @@
     };
 
     // support for POST requests, just define them here.
-    if (options.hasOwnProperty('postData') && options.hasOwnProperty('type')) {
+    if (options.hasOwnProperty('data') && options.hasOwnProperty('type')) {
       this.params.type = options.type;
-      this.params.data = options.postData;
+      this.params.data = options.data;
     }
 
   };


### PR DESCRIPTION
I've added support for POST requests on remote importers (by passing the `type` and `postData` parameters to the importer). It's a small change which might help?
