### PR TITLE
Add extract option to GoogleSpreadsheet Importer

### DIFF
--- a/src/importers/google_spreadsheet.js
+++ b/src/importers/google_spreadsheet.js
@@ -55,6 +55,7 @@
       }
     }
     
+    this.extract = options.extract || this.extract;
 
     this.params = {
       type : "GET",


### PR DESCRIPTION
Sometimes you want to have access to the raw data. E.g. when you want to get the updated time via `data.feed.updated.$t`.
